### PR TITLE
Update Functions.psm1 to also search HKLM

### DIFF
--- a/Launcher/Functions.psm1
+++ b/Launcher/Functions.psm1
@@ -103,17 +103,29 @@ function Convert-BatToGitOptions ($batFile) {
     return $GitOptions
 }
 function Search-RegForPyPath {
-    $pyCore = Get-ItemProperty -path "hkcu:\Software\Python\PythonCore\3.10\InstallPath"
-    if ($pyCore) {
-        $path = $pyCore.ExecutablePath
-        logger.info "Python 3.10 path found :`n$path"
-        return $path
+    $RegPaths = "HKCU:\Software\Python\PythonCore\3.10\InstallPath", "HKLM:\SOFTWARE\Python\PythonCore\3.10\InstallPath" 
+
+    if (Test-Path $RegPaths[0]) {
+        $pyCore = Get-ItemProperty -path $RegPaths[0] -ErrorAction SilentlyContinue
+    }
+    elseif (Test-Path $RegPaths[0]) {
+        $pyCore = Get-ItemProperty -path $RegPaths[1] -ErrorAction SilentlyContinue
     }
     else {
-        logger.warn "Python 3.10 not found, you probably have the wrong version installed and the WebUI might not work"
-        return ""
+        $pyCore = ""
     }
     
+    if ($pyCore) {
+        $pyPath = $pyCore.ExecutablePath
+        logger.info "Python 3.10 path found :`n$pyPath"
+        return $pyPath
+    }
+    else {
+        logger.warn "Python 3.10 not found on system."
+        logger.warn "Python is either missing or the registry entry in HKCU (single user install) or HKLM (multi-user install) is corrupted."
+        logger.warn "Expected regpath is one of the following: 'HKCU:\Software\Python\PythonCore\3.10\InstallPath', 'HKLM:\SOFTWARE\Python\PythonCore\3.10\InstallPath'"
+        return ""
+    } 
 }
 function Format-Config($config) {
     $config2 = @()


### PR DESCRIPTION
Python's installation path is registered in either HKCU (HKey Current User) OR HKLM (HKey Local Machine) depending on whether a single-user or multi-user install is selected at install time. The original function only looked in HKCU which meant that, in instances where Python was installed "for all users", the launcher would halt unexpectedly even though there is a python version installed. This patch fixes that issue.

It also accounts for situations where /neither/ HCKU nor HKLM have an install path populated. This usually suggests that something is very wrong with the Python install. The error message was made more verbose to assist with debugging such issues.